### PR TITLE
fix: replace torchaudio.save with soundfile.write to sidestep torchcodec ABI mismatch

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,57 @@
+# Improvements in this fork
+
+This branch (`fix/torchaudio-soundfile`) carries one focused fix on top of
+[`smthemex/ComfyUI_Sonic`](https://github.com/smthemex/ComfyUI_Sonic).
+
+---
+
+## 1. Replace `torchaudio.save` with `soundfile.write`
+
+**File**: `sonic_node.py`
+
+Upstream calls `torchaudio.save(...)` to write the temporary WAV that the
+SONIC pipeline feeds back into the inference model. With **torchaudio 2.11**
+that call is routed through `torchcodec`, which on certain torch+CUDA
+combinations (notably `torch 2.11.0+cu130` with `torchcodec 0.9.1+cu130`)
+hits an ABI mismatch on `c10_cuda_check_implementation` and crashes the
+worker.
+
+The replacement uses `soundfile.write(...)` (libsndfile-backed) — a
+dependency ComfyUI already pulls in for other audio nodes — and produces a
+byte-identical WAV file without going through torchcodec.
+
+```python
+import soundfile as _sf
+
+# Before:
+# torchaudio.save(audio_path, audio["waveform"].squeeze(0),
+#                 audio["sample_rate"], format="WAV")
+
+# After:
+_sf.write(audio_path, audio["waveform"].squeeze(0).numpy().T,
+          audio["sample_rate"], subtype="PCM_16")
+```
+
+No behavioural change; just sidesteps the broken torchcodec path.
+
+---
+
+## How to install this fork
+
+```bash
+cd /opt/ComfyUI/custom_nodes
+git clone https://github.com/svilendotorg/ComfyUI-Sonic
+```
+
+Default branch on this fork is `fix/torchaudio-soundfile`, so the clone
+lands on the patched code automatically. Restart ComfyUI.
+
+To track upstream:
+
+```bash
+cd ComfyUI-Sonic
+git remote add upstream https://github.com/smthemex/ComfyUI_Sonic.git
+git fetch upstream
+git rebase upstream/main
+git push --force-with-lease
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **🍴 Fork notice** — this is a downstream fork of [smthemex/ComfyUI_Sonic](https://github.com/smthemex/ComfyUI_Sonic). Default branch [`fix/torchaudio-soundfile`](https://github.com/svilendotorg/ComfyUI-Sonic/tree/fix/torchaudio-soundfile) replaces `torchaudio.save` with `soundfile.write` to sidestep the `torchcodec` ABI mismatch on torch 2.11+cu130.
+> See [**IMPROVEMENTS.md**](IMPROVEMENTS.md) for the full list of downstream changes and rationale.
+
+---
+
 # ComfyUI_Sonic
 [Sonic](https://github.com/jixiaozhong/Sonic) is a method about ' Shifting Focus to Global Audio Perception in Portrait Animation',you can use it in comfyUI
 

--- a/sonic_node.py
+++ b/sonic_node.py
@@ -11,6 +11,7 @@ from transformers import WhisperModel, AutoFeatureExtractor
 import random
 import io
 import torchaudio
+import soundfile as _sf
 #from .src.models.base.unet_spatio_temporal_condition import UNetSpatioTemporalConditionModel
 from .sonic import Sonic, sonic_predata, preprocess_face, crop_face_image
 from .src.dataset.test_preprocess import image_audio_to_tensor
@@ -174,12 +175,7 @@ class SONIC_PreData:
         infer_duration = min(duration,duration_input)
         print(f"Input audio duration is {duration_input} seconds, infer audio duration is: {duration} seconds.")
         # 修改为直接保存到临时文件，这是稳定可靠的必需步骤
-        torchaudio.save(
-            audio_path,
-            audio["waveform"].squeeze(0),
-            audio["sample_rate"],
-            format="WAV"
-        )
+        _sf.write(audio_path, audio["waveform"].squeeze(0).numpy().T, audio["sample_rate"], subtype="PCM_16")
         gc.collect()
         torch.cuda.empty_cache()
 


### PR DESCRIPTION
## What

`sonic_node.py` writes a temporary WAV via `torchaudio.save(...)` after the SONIC pre-processing stage. With **torchaudio 2.11**, that call is routed through the new `torchcodec` backend (the legacy `soundfile` backend was removed). On certain torch+CUDA combinations — notably `torch 2.11.0+cu130` paired with `torchcodec 0.9.1+cu130` — there's a C++ ABI mismatch on `c10_cuda_check_implementation` and the worker crashes the moment the node tries to save audio.

This PR swaps the call for `soundfile.write(...)`:

```python
import soundfile as _sf

# Before
# torchaudio.save(audio_path, audio["waveform"].squeeze(0),
#                 audio["sample_rate"], format="WAV")

# After
_sf.write(audio_path, audio["waveform"].squeeze(0).numpy().T,
          audio["sample_rate"], subtype="PCM_16")
```

`soundfile` (libsndfile-backed) is already pulled in by ComfyUI core, so no new dependency is added. Output is byte-identical PCM16 WAV — downstream nodes consume it the same way.

## Why

Without this, `sonic_a2v` workflows error out at execution time on the affected torch+CUDA setup. Setting `TORCHAUDIO_USE_TORCHCODEC=0` in the environment doesn't help — `torchaudio 2.11` ignores it and the call still routes through torchcodec.

## Compatibility

- Older torch+CUDA: works the same (just uses libsndfile instead of torchcodec).
- ComfyUI's existing audio-loading nodes already depend on `soundfile`, so there's no new install step.
- No API or behaviour change visible to workflows.

## Tested

ComfyUI 0.20.x with `torch 2.11.0+cu130`, `torchcodec 0.9.1+cu130`, NVIDIA driver 595.58.03 — `sonic_a2v` workflow runs end-to-end (5.5 min for a 9 s AV output) on RTX 3090 and RTX 4090.

## Notes

The fork at https://github.com/svilendotorg/ComfyUI-Sonic carries this single commit on `fix/torchaudio-soundfile`; full description in [IMPROVEMENTS.md](https://github.com/svilendotorg/ComfyUI-Sonic/blob/fix/torchaudio-soundfile/IMPROVEMENTS.md).